### PR TITLE
Fixed kali GPG error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-apt-key adv --keyserver pgp.mit.edu --recv-keys ED444FF07D8D0BF6
+wget https://http.kali.org/kali/pool/main/k/kali-archive-keyring/kali-archive-keyring_2018.1_all.deb
+apt install ./kali-archive-keyring_2018.1_all.deb
 echo "deb http://http.kali.org/kali kali-rolling main contrib non-free" >> /etc/apt/sources.list
 echo "deb http://repo.kali.org/kali kali-bleeding-edge main' >> /etc/apt/sources.list"
 apt-get update  


### PR DESCRIPTION
Kali key on pgp.mit.edu is no longer avalible