### PR TITLE
Changed autoconnection disable

### DIFF
--- a/WiFiSpam.sh
+++ b/WiFiSpam.sh
@@ -7,7 +7,7 @@ clear
 >nul iwconfig $AD mode managed
 >nul ifconfig $AD up
 >nul rm RANDOM_wordlist.txt
->nul service network-manager start
+>nul nmcli device connect $AD
 clear
 title
 echo -e "\e[1;31m   Thanks for using this script"
@@ -46,7 +46,7 @@ echo -n -e "\e[1;37m"
 read DD
 clear
 if [ $DD == 1 ]; then
-	service network-manager stop
+	nmcli device disconnect $AD
 	clear
 	title
 	echo -e "\e[1;32mStarting process..."
@@ -62,7 +62,7 @@ if [ $DD == 1 ]; then
 	mdk3 $AD b -f ./SSID_List.txt -a -s 1000
 fi
 if [ $DD == 2 ]; then
-	service network-manager stop
+	nmcli device disconnect $AD
 	clear
 	title
 	echo -n -e "\e[1;34mWrite your string/word (Max. length: 12) > "
@@ -91,7 +91,7 @@ if [ $DD == 2 ]; then
 	mdk3 $AD b -f ./$WORD"_wordlist.txt" -a -s 1000
 fi
 if [ $DD == 3 ]; then
-	service network-manager stop
+	nmcli device disconnect $AD
 	title
 	echo -e "\e[1;37mPlease, note that your word list must have the same structure as SSID_List.txt, otherwise the process won't work."
 	echo " "
@@ -112,7 +112,7 @@ if [ $DD == 3 ]; then
 	mdk3 $AD b -f ./$OWN -a -s $(wc -l $OWN | cut -f1 -d ' ')
 fi
 if [ $DD == 4 ]; then
-	service network-manager stop
+	nmcli device disconnect $AD
 	title
 	echo -n -e "\e[1;34mHow many SSIDs do you want? > "
 	echo -n -e "\e[1;37m"


### PR DESCRIPTION
Changed autoconnection disable due to network-manager disabling all wifi devices after service stop on some distros.